### PR TITLE
Fix multiple files

### DIFF
--- a/src/controllers/main.controller.ts
+++ b/src/controllers/main.controller.ts
@@ -76,14 +76,8 @@ export class MainController {
       const directory = this._createTmpDir(codeBlock.id);
 
       // Open an editor for each file in CodeFile
-      let i = 0;
       for(let fileName in codeBlock.files) {
-        i++;
         let file = codeBlock.files[fileName];
-        if (i > 1) {
-          await commands.executeCommand('workbench.action.focusFirstEditorGroup');
-          await commands.executeCommand('workbench.action.splitEditor');
-        }
         await this._openTextDocument(directory, fileName, file.content);
       }
     } catch (error) {
@@ -332,7 +326,8 @@ export class MainController {
     let file = path.join(dir, filename);
     fs.writeFileSync(file, content);
     return workspace.openTextDocument(file)
-      .then((doc: TextDocument) => window.showTextDocument(doc));
+      .then((doc: TextDocument) => window.showTextDocument(doc))
+      .then(() => commands.executeCommand('workbench.action.keepEditor'));
   }
   
   private async _loginUser() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This resolves the issue where a multi-file gist would only ever open the first two and the last file (3 files) limited to the number of split editors. The solution is to open a file and trigger the `workbench.action.keepEditor` command.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#18 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![vscode-gist-multi-file](https://user-images.githubusercontent.com/1892667/32514276-6062c9ec-c3b1-11e7-8f38-7e6dd4f3e071.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
