### PR TITLE
Don't include .vscode-test in build

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode/**
+.vscode-test/**
 typings/**
 out/test/**
 test/**


### PR DESCRIPTION
The extension build contains an unused `.vscode-test`.

## Description

Exclude `.vscode-test` folder from the build via configuration.


## Related Issue

This should close #33.



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
