### PR TITLE
Copy the Gist URL to the clipboard after a Gist is created

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "kenhowardpdx",
   "repository": "https://github.com/kenhowardpdx/vscode-gist",
   "engines": {
-    "vscode": "^1.28.0"
+    "vscode": "^1.30.0"
   },
   "categories": [
     "Other"
@@ -127,7 +127,7 @@
     "ts-jest": "^23.10.4",
     "tslint": "^5.11.0",
     "typescript": "^3.1.6",
-    "vscode": "^1.1.21"
+    "vscode": "^1.1.26"
   },
   "dependencies": {
     "@octokit/rest": "^16.1.0",

--- a/src/commands/gists/create.ts
+++ b/src/commands/gists/create.ts
@@ -1,4 +1,4 @@
-import { window } from 'vscode';
+import { window, env } from 'vscode';
 
 import { GistCommands } from '../extension-commands';
 
@@ -47,6 +47,8 @@ const create: CommandInitializer = (
       );
 
       await openGist(gist, config.get<number>('maxFiles'));
+      env.clipboard.writeText(gist.url);
+
     } catch (err) {
       const context = gistName ? ` ${gistName}` : '';
       const error: Error = err as Error;


### PR DESCRIPTION
## Description
This automatically puts the Gist URL into the clipboard after a new Gist is created so that it can be easily shared with someone else.

## Related Issue
https://github.com/kenhowardpdx/vscode-gist/issues/92

## Motivation and Context
Often the reason for creating a new Gist is to share it with someone easily. This unobtrusively gives the user the option to do that by putting it in their clipboard.

## How Has This Been Tested?
I tested this using the Debug mode of VSCode and it worked as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
