### PR TITLE
New insert favorite gist command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ GIST: Delete File
 GIST: Add File
 GIST: Open Gist In Browser
 GIST: Insert Text From Gist File
+GIST: Insert Text From Favorite Gist File
 ~~~
 
 ## Extension Settings
@@ -104,6 +105,7 @@ Here is a list of commands and their mapped keyboard shortcuts
 |extension.gist.deleteFile|Delete File|not mapped|
 |extension.gist.add|Add File|ctrl+alt+a ctrl+alt+a|
 |extension.gist.insert|Insert Text From Gist File|not mapped|
+|extension.gist.insertFavorite|Insert Text From Favorite Gist File|not mapped|
 |extension.profile.select|Select Profile|ctrl+alt+=|
 |extension.resetState|n/a|ctrl+shift+0|Delete All Extension Memory (removes auth tokens)|
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
         "category": "GIST"
       },
       {
+        "command": "extension.gist.insertFavorite",
+        "title": "Insert Text From Favorite Gist File",
+        "category": "GIST"
+      },
+      {
         "command": "extension.profile.select",
         "title": "Select Profile",
         "category": "GIST"

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -13,6 +13,7 @@ const commandInitializers: CommandInitializer[] = [
   gists.deleteCommand,
   gists.deleteFile,
   gists.insert,
+  gists.insertFavorite,
   gists.open,
   gists.openFavorite,
   gists.openInBrowser,

--- a/src/commands/extension-commands.ts
+++ b/src/commands/extension-commands.ts
@@ -5,6 +5,7 @@ enum GistCommands {
   Delete = 'extension.gist.delete',
   DeleteFile = 'extension.gist.deleteFile',
   Insert = 'extension.gist.insert',
+  InsertFavorite = 'extension.gist.insertFavorite',
   Open = 'extension.gist.open',
   OpenFavorite = 'extension.gist.openFavorite',
   OpenInBrowser = 'extension.gist.openInBrowser',

--- a/src/commands/gists/__tests__/insert-favorite.test.ts
+++ b/src/commands/gists/__tests__/insert-favorite.test.ts
@@ -1,0 +1,133 @@
+// tslint:disable:no-any no-magic-numbers no-unsafe-any
+import { window } from 'vscode';
+
+import { insertFavorite } from '../insert-favorite';
+
+jest.mock('fs');
+jest.mock('path');
+
+const showQuickPickSpy = jest.spyOn(window, 'showQuickPick');
+
+const getGistsMock = jest.fn(() => [
+  {
+    createdAt: new Date(),
+    description: 'some markdown file',
+    fileCount: 1,
+    files: { 'file-one.md': { content: 'test' } },
+    id: '123',
+    name: 'gist one',
+    public: true,
+    updatedAt: new Date()
+  },
+  {
+    createdAt: new Date(),
+    description: 'some markdown file',
+    fileCount: 1,
+    files: { 'file-two.md': { content: 'test' } },
+    id: '123',
+    name: 'gist two',
+    public: true,
+    updatedAt: new Date()
+  }
+]);
+
+const updateGistMock = jest.fn();
+const getGistMock = jest.fn((id: string) => ({
+  createdAt: new Date(),
+  description: 'some markdown file',
+  fileCount: 1,
+  files: {
+    'file-one.md': { content: 'test' },
+    'file-two.md': { content: 'test' }
+  },
+  id,
+  name: 'test',
+  public: true,
+  updatedAt: new Date()
+}));
+const utilsMock = jest.genMockFromModule<Utils>('../../../utils');
+const errorMock = jest.fn();
+
+describe('insert favorite gist', () => {
+  let insertFavoriteFn: CommandFn;
+  beforeEach(() => {
+    const gists = {
+      getGist: getGistMock,
+      getGists: getGistsMock,
+      updateGist: updateGistMock
+    };
+    const insights = { exception: jest.fn() };
+    const logger = { debug: jest.fn(), error: errorMock, info: jest.fn() };
+    insertFavoriteFn = insertFavorite(
+      { get: jest.fn() },
+      { gists, insights, logger } as any,
+      utilsMock as any
+    )[1];
+    window.activeTextEditor = <any>{
+      document: { getText: jest.fn() },
+      selection: { isEmpty: true }
+    };
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  test('should log error when no editor', async () => {
+    expect.assertions(1);
+
+    (<any>window.activeTextEditor) = undefined;
+
+    await insertFavoriteFn();
+    expect(errorMock.mock.calls.length).toBe(1);
+  });
+  test('what happens when errors occur', async () => {
+    expect.assertions(1);
+
+    (<any>utilsMock.input.quickPick).mockRejectedValueOnce(false);
+
+    await insertFavoriteFn();
+    expect(errorMock.mock.calls.length).toBe(1);
+  });
+  test('it should prompt the user to select a gist', async () => {
+    expect.assertions(1);
+
+    await insertFavoriteFn();
+
+    expect((<any>utilsMock).input.quickPick).toHaveBeenCalledWith([
+      expect.any(Object),
+      expect.any(Object)
+    ]);
+  });
+  test('it should query for the users selected gist', async () => {
+    expect.assertions(1);
+
+    (<any>utilsMock.input.quickPick).mockResolvedValueOnce({
+      block: { id: '123' }
+    });
+
+    await insertFavoriteFn();
+
+    expect(getGistMock).toHaveBeenCalledWith('123');
+  });
+  test('it should prompt the user to select a file if more than one is available', async () => {
+    expect.assertions(1);
+
+    (<any>utilsMock.input.quickPick).mockResolvedValueOnce({
+      block: { id: '123' }
+    });
+
+    await insertFavoriteFn();
+
+    expect(showQuickPickSpy).toHaveBeenCalledWith([
+      {
+        description: '',
+        'file-one.md': expect.any(Object),
+        label: 'file-one.md'
+      },
+      {
+        description: '',
+        'file-two.md': expect.any(Object),
+        label: 'file-two.md'
+      }
+    ]);
+  });
+});

--- a/src/commands/gists/index.ts
+++ b/src/commands/gists/index.ts
@@ -4,6 +4,7 @@ export * from './create-confirmation';
 export * from './delete';
 export * from './delete-file';
 export * from './insert';
+export * from './insert-favorite';
 export * from './open';
 export * from './open-favorite';
 export * from './open-in-browser';

--- a/src/commands/gists/insert-favorite.ts
+++ b/src/commands/gists/insert-favorite.ts
@@ -1,0 +1,51 @@
+import { window } from 'vscode';
+
+import { GistCommands } from '../extension-commands';
+
+import { insertText, selectFile } from './utils';
+
+const insertFavorite: CommandInitializer = (
+  _config: Configuration,
+  services: Services,
+  utils: Utils
+): [Command, CommandFn] => {
+  const { gists, logger } = services;
+
+  const command = GistCommands.InsertFavorite;
+
+  const commandFn = async (): Promise<void> => {
+    try {
+      const editor = window.activeTextEditor;
+      if (!editor) {
+        throw new Error('Open a file before inserting');
+      }
+
+      const list = await gists.getGists(true);
+      const selected = await utils.input.quickPick(list);
+
+      if (!selected) {
+        services.logger.debug('No gist selected');
+
+        return;
+      }
+
+      const gist = await gists.getGist(selected.block.id);
+      // selected file to insert
+      const file = await selectFile(gist);
+      if (!file) {
+        services.logger.debug('No file selected');
+
+        return;
+      }
+      await insertText(editor, file.content);
+    } catch (err) {
+      const error: Error = err as Error;
+      logger.error(`${command} > ${error && error.message}`);
+      utils.notify.error('Could Not Insert', `Reason: ${error.message}`);
+    }
+  };
+
+  return [command, commandFn];
+};
+
+export { insertFavorite };


### PR DESCRIPTION
## Description
Add new command to insert starred gist.

## Related Issue
#142

## Motivation and Context
I use gist to manage my snippets, and it would be great if I could insert starred gist as well as my own.

## How Has This Been Tested?
I manually tested that the command can be called from the command palette, that quickpick shows all starred gists, and that the editor inserts the texts.
And, I add test script with reference to the insert command.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
